### PR TITLE
fix(adjust-grub-theme): terminal font has cursor image residue

### DIFF
--- a/adjust-grub-theme/version.go
+++ b/adjust-grub-theme/version.go
@@ -1,3 +1,3 @@
 package main
 
-const VERSION int = 12
+const VERSION int = 13

--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,7 @@ Homepage: http://www.deepin.org
 Package: dde-api
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
- rfkill, locales, libcanberra-pulse, blur-effect, librsvg2-bin, fonts-noto-cjk, fonts-noto-mono,
+ rfkill, locales, libcanberra-pulse, blur-effect, librsvg2-bin, fonts-noto-cjk, ttf-unifont,
  bc, fontconfig, coreutils, alsa-utils
 Description: Go-lang bingdings for dde-daemon
  Deepin Go-lang bindings for dde-daemon

--- a/misc/data/grub-themes/deepin/theme.txt.tpl
+++ b/misc/data/grub-themes/deepin/theme.txt.tpl
@@ -2,7 +2,7 @@
 title-text: ""
 desktop-image: "background.jpg"
 desktop-color: "#000000"
-terminal-font: "Noto Mono:style=Regular;1"
+terminal-font: "Unifont:style=Medium;1"
 terminal-box: "terminal_box_*.png"
 terminal-left: "0"
 terminal-top: "0"


### PR DESCRIPTION
https://github.com/linuxdeepin/internal-discussion/issues/960

Change-Id: I51bba09c7aa0017bdb1461fef881347b6ca6479a