### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,17 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-api.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-api.spec
+    - .packit.yaml
+
+upstream_package_name: dde-api
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-api
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-api.spec"

--- a/rpm/deepin-api.spec
+++ b/rpm/deepin-api.spec
@@ -1,0 +1,152 @@
+# Run tests in check section
+# disable for bootstrapping
+%bcond_with check
+
+# out of memory on armv7hl
+%ifarch %{arm}
+%global _smp_mflags -j1
+%endif
+
+%global goipath  pkg.deepin.io/dde/api
+%global forgeurl https://github.com/linuxdeepin/dde-api
+Version:         5.3.0.12
+%global tag     %{version}
+
+%gometa
+
+Name:           deepin-api
+Release:        1%{?dist}
+Summary:        Go-lang bingding for dde-daemon
+License:        GPLv3+
+URL:            %{gourl}
+Source0:        %{gosource}
+
+BuildRequires:  pkgconfig(alsa)
+BuildRequires:  pkgconfig(cairo-ft)
+BuildRequires:  pkgconfig(gio-2.0)
+BuildRequires:  pkgconfig(gtk+-3.0)
+BuildRequires:  pkgconfig(gdk-pixbuf-xlib-2.0)
+BuildRequires:  pkgconfig(gudev-1.0)
+BuildRequires:  pkgconfig(libcanberra)
+BuildRequires:  pkgconfig(libpulse-simple)
+BuildRequires:  pkgconfig(librsvg-2.0)
+BuildRequires:  pkgconfig(poppler-glib)
+BuildRequires:  pkgconfig(polkit-qt5-1)
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  pkgconfig(xfixes)
+BuildRequires:  pkgconfig(xcursor)
+BuildRequires:  pkgconfig(x11)
+BuildRequires:  pkgconfig(xi)
+BuildRequires:  deepin-gettext-tools
+BuildRequires:  deepin-gir-generator
+BuildRequires:  golang(pkg.deepin.io/lib)
+BuildRequires:  golang(github.com/linuxdeepin/go-x11-client)
+BuildRequires:  golang(github.com/linuxdeepin/go-dbus-factory/org.bluez)
+BuildRequires:  golang(github.com/BurntSushi/xgb)
+BuildRequires:  golang(github.com/BurntSushi/xgbutil)
+BuildRequires:  golang(github.com/disintegration/imaging)
+BuildRequires:  golang(github.com/cryptix/wav)
+BuildRequires:  golang(github.com/fogleman/gg)
+BuildRequires:  golang(github.com/nfnt/resize)
+BuildRequires:  golang(gopkg.in/alecthomas/kingpin.v2)
+BuildRequires:  golang(github.com/mattn/go-sqlite3)
+BuildRequires:  golang(github.com/gosexy/gettext)
+BuildRequires:  golang(github.com/rickb777/date)
+%{?systemd_requires}
+Requires:       deepin-desktop-base
+Requires:       rfkill
+Requires(pre):  shadow-utils
+
+%description
+%{summary}.
+
+%package -n golang-%{name}-devel
+Summary:        %{summary}
+BuildArch:      noarch
+
+%description -n golang-%{name}-devel
+%{summary}.
+
+This package contains library source intended for
+building other packages which use import path with
+%{goipath} prefix.
+
+%prep
+%goprep
+
+sed -i 's|/usr/lib|%{_libexecdir}|' misc/*services/*.service \
+    misc/systemd/system/deepin-shutdown-sound.service \
+    lunar-calendar/main.go \
+    theme_thumb/gtk/gtk.go \
+    thumbnails/gtk/gtk.go
+
+sed -i 's|boot/grub/|boot/grub2/|' adjust-grub-theme/main.go
+
+# add targets to print the binaries and libraries, so we can build/install them
+# in Fedora style
+cat <<EOF >> Makefile
+print_binaries:
+	@echo \${BINARIES}
+
+print_libraries:
+	@echo \${LIBRARIES}
+EOF
+
+%build
+# upstream Makefile expects binaries generated to out/bin
+for cmd in $(make print_binaries); do
+    %gobuild -o out/bin/$cmd %{goipath}/$cmd
+done
+# don't build binaries or libraries based on Makefile
+%make_build ts-to-policy
+
+%install
+# install dev libraries mannally
+gofiles=$(find $(make print_libraries) %{?gofindfilter} -print)
+%goinstall $gofiles
+# install binaries based on Makefile
+%__make DESTDIR=%{buildroot} SYSTEMD_SERVICE_DIR="%{_unitdir}" libdir=/libexec GOBUILD_DIR=_build install-binary
+# HOME directory for user deepin-sound-player
+mkdir -p %{buildroot}%{_sharedstatedir}/deepin-sound-player
+
+%if %{with check}
+%check
+%gochecks
+%endif
+
+%pre
+getent group deepin-sound-player >/dev/null || groupadd -r deepin-sound-player
+getent passwd deepin-sound-player >/dev/null || \
+    useradd -r -g deepin-sound-player -d %{_sharedstatedir}/deepin-sound-player\
+    -s /sbin/nologin \
+    -c "User of com.deepin.api.SoundThemePlayer.service" deepin-sound-player
+exit 0
+
+%post
+%systemd_post deepin-shutdown-sound.service
+
+%preun
+%systemd_preun deepin-shutdown-sound.service
+
+%postun
+%systemd_postun_with_restart deepin-shutdown-sound.service
+
+%files
+%doc README.md
+%license LICENSE
+%{_bindir}/dde-open
+%{_libexecdir}/%{name}/
+%{_unitdir}/*.service
+%{_datadir}/dbus-1/services/*.service
+%{_datadir}/dbus-1/system-services/*.service
+%{_datadir}/dbus-1/system.d/*.conf
+%{_datadir}/icons/hicolor/*/actions/*
+%{_datadir}/dde-api
+%{_datadir}/polkit-1/actions/com.deepin.api.locale-helper.policy
+%{_datadir}/polkit-1/actions/com.deepin.api.device.unblock-bluetooth-devices.policy
+%{_var}/lib/polkit-1/localauthority/10-vendor.d/com.deepin.api.device.pkla
+%attr(-, deepin-sound-player, deepin-sound-player) %{_sharedstatedir}/deepin-sound-player
+
+%files -n golang-%{name}-devel -f devel.file-list
+
+%changelog


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: