### PR TITLE
fix: rpm BuildRequires make

### DIFF
--- a/rpm/deepin-api.spec
+++ b/rpm/deepin-api.spec
@@ -9,7 +9,7 @@
 
 %global goipath  pkg.deepin.io/dde/api
 %global forgeurl https://github.com/linuxdeepin/dde-api
-Version:         5.3.0.12
+Version:         5.3.0.14
 %global tag     %{version}
 
 %gometa
@@ -52,6 +52,7 @@ BuildRequires:  golang(gopkg.in/alecthomas/kingpin.v2)
 BuildRequires:  golang(github.com/mattn/go-sqlite3)
 BuildRequires:  golang(github.com/gosexy/gettext)
 BuildRequires:  golang(github.com/rickb777/date)
+BuildRequires:  make
 %{?systemd_requires}
 Requires:       deepin-desktop-base
 Requires:       rfkill


### PR DESCRIPTION
Fedora no longer installs make in the default build environment.

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>