### PR TITLE
chore: dont set PATH env

### DIFF
--- a/device/main.go
+++ b/device/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/linuxdeepin/go-lib/dbusutil"
@@ -15,7 +14,6 @@ import (
 var logger = log.NewLogger(dbusServiceName)
 
 func main() {
-	os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	service, err := dbusutil.NewSystemService()
 	if err != nil {
 		logger.Fatal("failed to new system service:", err)

--- a/locale-helper/main.go
+++ b/locale-helper/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"sync"
 	"time"
@@ -45,7 +44,6 @@ var (
 )
 
 func main() {
-	os.Setenv("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
 	logger.BeginTracing()
 	defer logger.EndTracing()
 


### PR DESCRIPTION
Log: dbus 环境缺失环境变量应该由 dbus-update-activation-environment 处理 ,不应该由 dde-api 设置 PATH