### PR TITLE
fix: deepin grub主题配置文件模板theme.txt.tpl中，部分font内容不规范，导致adjust-grub-theme生成了不符合预期的字体

### DIFF
--- a/misc/data/grub-themes/deepin/theme.txt.tpl
+++ b/misc/data/grub-themes/deepin/theme.txt.tpl
@@ -16,7 +16,7 @@ terminal-border: "0"
   top = "(screen_height - height) / 2"
   width = "1.7 * height"
   height = "6*item_spacing + 8*item_height + 2*item_r + 3"
-  item_font = "Noto Sans CJK SC Regular;1"
+  item_font = "Noto Sans CJK SC :style=Regular;1"
   item_color = "#dddddd"
   selected_item_color = "#ffffff"
   item_height = "font_height * 1.574"
@@ -62,7 +62,7 @@ terminal-border: "0"
   # zh_HK
   _text_zh_HK = "在 %d 秒內啟動"
   color = "#99E53E"
-  font = "Noto Sans CJK SC Regular;0.85"
+  font = "Noto Sans CJK SC :style=Regular;0.85"
 }
 
 # Navigation keys hint 
@@ -95,6 +95,6 @@ terminal-border: "0"
   # zh_HK
   _text_zh_HK = "使用 ↑ 和 ↓ 鍵移動選擇條，Enter 鍵確認，E 鍵編輯啟動命令，C 鍵進入命令行"
   color = "#99E53E"
-  font = "Noto Sans CJK SC Regular;0.85"
+  font = "Noto Sans CJK SC :style=Regular;0.85"
 }
 


### PR DESCRIPTION

修改“Noto Sans CJK SC Regular;1” -> “Noto Sans CJK SC :style=Regular;1” 
使adjust-grub-theme在根据theme.txt.tpl中的font内容查找字体时，可以找到正确的“Noto Sans CJK SC Regular”字体：“/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc”，而非目前程序中得到的结果“/usr/share/fonts/truetype/noto/NotoSans-Regular.ttf”