### PR TITLE
fix: get 'libinput Accel Profiles Available' failed

### DIFF
--- a/dxinput/libinput.go
+++ b/dxinput/libinput.go
@@ -43,33 +43,33 @@ const (
 	libinputPropDisableWhileTyping = "libinput Disable While Typing Enabled"
 )
 
-// for mouse: check if both "adaptive" and "flat" profile are avaliable
+// for mouse: check if both "adaptive", "flat" and "custom" profile are avaliable
 func libinputIsBothAccelProfileAvaliable(id int32) bool {
-	available, err := getInt8Prop(id, libinputPropAccelProfileAvaliable, 2)
+	available, err := getInt8Prop(id, libinputPropAccelProfileAvaliable, 3)
 	if err != nil {
 		return false
 	}
 
-	return (available[0] == 1) && (available[1] == 1)
+	return (available[0] == 1) && (available[1] == 1) && (available[2] == 1)
 }
 
-// for mouse: get enabled accel profile, in order "adaptive", "flat".
-func libinputGetAccelProfile(id int32) (bool, bool) {
-	enabled, err := getInt8Prop(id, libinputPropAccelProfileEnabled, 2)
+// for mouse: get enabled accel profile, in order "adaptive", "flat", "custom".
+func libinputGetAccelProfile(id int32) (bool, bool, bool) {
+	enabled, err := getInt8Prop(id, libinputPropAccelProfileEnabled, 3)
 	if err != nil {
-		return false, false
+		return false, false, false
 	}
 
-	return enabled[0] == 1, enabled[1] == 1
+	return enabled[0] == 1, enabled[1] == 1, enabled[2] == 1
 }
 
-// for mouse: set enabled accel profile, in order "adaptive", "flat".
+// for mouse: set enabled accel profile, in order "adaptive", "flat", "custom".
 func libinputSetAccelProfile(id int32, useAdaptiveProfile bool) error {
 	if !libinputIsBothAccelProfileAvaliable(id) {
 		return errors.New("dde-api: device doesn't support both accel profile")
 	}
 
-	prop, err := getInt8Prop(id, libinputPropAccelProfileEnabled, 2)
+	prop, err := getInt8Prop(id, libinputPropAccelProfileEnabled, 3)
 	if err != nil {
 		return err
 	}
@@ -77,9 +77,11 @@ func libinputSetAccelProfile(id int32, useAdaptiveProfile bool) error {
 	if useAdaptiveProfile {
 		prop[0] = 1
 		prop[1] = 0
+		prop[2] = 0
 	} else {
 		prop[0] = 0
 		prop[1] = 1
+		prop[2] = 0
 	}
 
 	return utils.SetInt8Prop(id, libinputPropAccelProfileEnabled, prop)

--- a/dxinput/mouse.go
+++ b/dxinput/mouse.go
@@ -129,13 +129,14 @@ func (m *Mouse) IsAdaptiveAccelProfileEnabled() bool {
 	if globalWayland {
 		return kwayland.CanAdaptiveAccelProfile(fmt.Sprintf("%s%d", kwayland.SysNamePrefix, m.Id))
 	}
-	adaptive, _ := libinputGetAccelProfile(m.Id)
+	adaptive, _, _ := libinputGetAccelProfile(m.Id)
 	return adaptive
 }
 
 // EnableMiddleButtonEmulation enable mouse middle button emulation
 // "Evdev Middle Button Emulation"
-//     1 boolean value (8 bit, 0 or 1).
+//
+//	1 boolean value (8 bit, 0 or 1).
 func (m *Mouse) EnableMiddleButtonEmulation(enabled bool) error {
 	if enabled == m.CanMiddleButtonEmulation() {
 		return nil
@@ -176,7 +177,8 @@ func (m *Mouse) CanMiddleButtonEmulation() bool {
 
 // SetMiddleButtonEmulationTimeout set middle button emulation timeout
 // "Evdev Middle Button Timeout"
-//     1 16-bit positive value.
+//
+//	1 16-bit positive value.
 func (m *Mouse) SetMiddleButtonEmulationTimeout(timeout int16) error {
 	if m.isLibinputUsed || globalWayland {
 		return fmt.Errorf("Libinput unsupport the property")
@@ -204,7 +206,8 @@ func (m *Mouse) MiddleButtonEmulationTimeout() (int16, error) {
 
 // EnableWheelEmulation enable mouse wheel emulation
 // "Evdev Wheel Emulation"
-//    1 boolean value (8 bit, 0 or 1).
+//
+//	1 boolean value (8 bit, 0 or 1).
 func (m *Mouse) EnableWheelEmulation(enabled bool) error {
 	if enabled == m.CanWheelEmulation() {
 		return nil
@@ -252,7 +255,8 @@ func (m *Mouse) CanWheelEmulation() bool {
 
 // SetWheelEmulationButton set wheel emulation button
 // "Evdev Wheel Emulation Button"
-//    1 8-bit value, allowed range 0-32, 0 disables the button.
+//
+//	1 8-bit value, allowed range 0-32, 0 disables the button.
 func (m *Mouse) SetWheelEmulationButton(btnNum int8) error {
 	old, _ := m.WheelEmulationButton()
 	if btnNum == old {
@@ -289,7 +293,8 @@ func (m *Mouse) WheelEmulationButton() (int8, error) {
 
 // SetWheelEmulationTimeout set wheel emulation timeout
 // "Evdev Wheel Emulation Timeout"
-//     1 16-bit positive value.
+//
+//	1 16-bit positive value.
 func (m *Mouse) SetWheelEmulationTimeout(timeout int16) error {
 	if m.isLibinputUsed || globalWayland {
 		return fmt.Errorf("Libinput unsupport the property")


### PR DESCRIPTION
libinput currently supports three profiles:
"adaptive", "flat" and "custom".

Log: 修复无法设置鼠标加速
PMS: bug-294369