### PR TITLE
fix: ps2触控板有事件上报，但是无法使用

### DIFF
--- a/dxinput/utils/list.c
+++ b/dxinput/utils/list.c
@@ -51,7 +51,8 @@ list_device(int* num)
     DeviceInfo* devs = NULL;
     for (i = 0; i < all_num; i++) {
         if ((xinfos[i].use != XISlavePointer &&
-                xinfos[i].use != XISlaveKeyboard)) {
+                xinfos[i].use != XISlaveKeyboard &&
+                xinfos[i].use != XIFloatingSlave)) {
             continue;
         }
 


### PR DESCRIPTION
xinput list可以看到触控板变成了floating，被dde-api过滤掉了

Log: 支持状态为floating的触控板
pms: BUG-298693