### PR TITLE
fix: debian build gopath error

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ ifneq ($(DEB_BUILD_ARCH), mips64el)
 endif
 
 %:
-	dh $@ --buildsystem=makefile
+	GO111MODULE=off dh $@ --buildsystem=makefile
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
解决GO111MODULE=off在部分环境下不生效导致的gopath错误

log: