### PR TITLE
feat: implement keyboard device management

### DIFF
--- a/dxinput/keyboard.go
+++ b/dxinput/keyboard.go
@@ -5,9 +5,60 @@
 package dxinput
 
 import (
+	"errors"
+	"fmt"
+
+	. "github.com/linuxdeepin/dde-api/dxinput/common"
+	"github.com/linuxdeepin/dde-api/dxinput/kwayland"
 	"github.com/linuxdeepin/dde-api/dxinput/utils"
 )
 
 func SetKeyboardRepeat(enabled bool, delay, interval uint32) error {
 	return utils.SetKeyboardRepeat(enabled, delay, interval)
+}
+
+type Keyboard struct {
+	Id   int32
+	Name string
+}
+
+func NewKeyboard(id int32) (*Keyboard, error) {
+	infos := utils.ListDevice()
+	if infos == nil {
+		return nil, errors.New("no device")
+	}
+
+	info := infos.Get(id)
+
+	if info == nil {
+		return nil, fmt.Errorf("invalid device id: %v", id)
+	}
+	return NewKeyboardDevInfo(info)
+}
+
+func NewKeyboardDevInfo(dev *DeviceInfo) (*Keyboard, error) {
+	if dev == nil || dev.Type != DevTypeKeyboard {
+		return nil, fmt.Errorf("not a keyboard device(%d - %s)", dev.Id, dev.Name)
+	}
+
+	return &Keyboard{
+		Id:   dev.Id,
+		Name: dev.Name,
+	}, nil
+}
+
+func (m *Keyboard) Enable(enabled bool) error {
+	if globalWayland {
+		return kwayland.Enable(fmt.Sprintf("%s%d", kwayland.SysNamePrefix, m.Id), enabled)
+	}
+
+	return enableDevice(m.Id, enabled)
+}
+
+func (m *Keyboard) IsEnabled() bool {
+	if globalWayland {
+		return kwayland.CanEnabled(fmt.Sprintf("%s%d", kwayland.SysNamePrefix, m.Id))
+	}
+
+	return isDeviceEnabled(m.Id)
 }


### PR DESCRIPTION
- Added Keyboard struct and associated methods for creating and managing keyboard devices.
- Introduced error handling for device creation and validation.
- Implemented functions to enable/disable keyboards and check their status.
- Added utility function to identify keyboard devices in the X11 environment.

Log: This enhancement improves keyboard device handling within the dxinput package.
pms: BUG-315763

## Summary by Sourcery

Implement keyboard device management in the dxinput package, including device creation, validation, enable/disable controls, and X11 detection.

New Features:
- Add Keyboard struct with constructors to create and validate keyboard devices
- Implement methods to enable, disable, and check status of keyboards on X11 and Wayland
- Add native is_keyboard_device function to detect keyboard devices in the X11 environment