### PR TITLE
chore: bump version to 6.0.18

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.18) unstable; urgency=medium
+
+  * feat: implement keyboard device management (#134)
+
+ -- fuleyi <fuleyi@uniontech.com>  Wed, 04 Jun 2025 15:40:30 +0800
+
 dde-api (6.0.17) unstable; urgency=medium
 
   * refactor: migrate from deepin-api-device to deepin-daemon user


### PR DESCRIPTION
update changelog to 6.0.18

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to 6.0.18