### PR TITLE
feat: use `deepin-immutable-ctrl` to wrap and call `locale-gen`

### DIFF
--- a/misc/systemd/system/deepin-locale-helper.service
+++ b/misc/systemd/system/deepin-locale-helper.service
@@ -12,12 +12,14 @@ ExecStart=/usr/lib/deepin-api/locale-helper
 
 ReadWritePaths=/etc/default/locale
 ReadWritePaths=/etc/locale.gen
-ReadWritePaths=/usr/lib/locale/
-ExecPaths=/usr/sbin/locale-gen
+
+# Temporary workaround: ReadWritePaths conflicts with deepin-immutable-ctl
+# TODO: Remove this comment when immutable system wraps locale-gen properly
+# ReadWritePaths=/usr/lib/locale/
 
 DevicePolicy=closed
 
-ProtectSystem=full
+ProtectSystem=strict
 ProtectHome=yes
 PrivateTmp=yes
 PrivateDevices=yes
@@ -29,7 +31,11 @@ ProtectKernelModules=yes
 ProtectKernelLogs=yes
 ProtectControlGroups=yes
 RestrictAddressFamilies=AF_UNIX
-RestrictNamespaces=yes
+
+# Need to call /usr/sbin/deepin-immutable-ctl command
+# TODO: Remove this comment when immutable system wraps locale-gen properly
+# RestrictNamespaces=yes
+
 LockPersonality=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes


### PR DESCRIPTION
Avoiding permission issues caused by immutable systems

Log: use `deepin-immutable-ctrl` to wrap and call `locale-gen`

## Summary by Sourcery

Wrap calls to locale-gen with deepin-immutable-ctl on immutable systems to avoid permission issues, falling back to direct execution when the wrapper is unavailable.

Bug Fixes:
- Fix permission errors on immutable systems by invoking locale-gen via deepin-immutable-ctl

Enhancements:
- Add detection of deepin-immutable-ctl and import utility for file existence checks
- Introduce deepin-immutable-ctl wrapper for both locale-gen and parameterized locale-gen calls with warning logs and output capture