### PR TITLE
fix: remove Install sections from systemd sound services

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,11 +20,4 @@ override_dh_strip:
 	dh_strip --dbgsym-migration=dde-api-dbg
 
 override_dh_installsystemd:
-	# 需要开机启动
-	dh_installsystemd --name=deepin-login-sound --no-start
-	dh_installsystemd --name=deepin-shutdown-sound --no-start
-
-	# 不需要开机启动
-	dh_installsystemd --name=deepin-api-device --no-enable --no-start
-	dh_installsystemd --name=deepin-locale-helper --no-enable --no-start
-	dh_installsystemd --name=deepin-sound-theme-player --no-enable --no-start
+	dh_installsystemd --no-start

--- a/misc/systemd/system/deepin-login-sound.service
+++ b/misc/systemd/system/deepin-login-sound.service
@@ -28,6 +28,3 @@ LockPersonality=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 RemoveIPC=yes
-
-[Install]
-WantedBy=multi-user.target

--- a/misc/systemd/system/deepin-shutdown-sound.service
+++ b/misc/systemd/system/deepin-shutdown-sound.service
@@ -36,6 +36,3 @@ LockPersonality=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 RemoveIPC=yes
-
-[Install]
-WantedBy=graphical.target


### PR DESCRIPTION
fix: remove Install sections from systemd sound services
1. Removed [Install] sections from both deepin-login-sound.service and
deepin-shutdown-sound.service
2. These services are meant to be triggered manually rather than being
enabled/started at boot
3. The WantedBy directives were unnecessary since these are one-shot
services
4. Improves system startup performance by not loading unnecessary
services

fix: 从 systemd 声音服务中移除 Install 部分

1. 从 deepin-login-sound.service 和 deepin-shutdown-sound.service 中移除
了 [Install] 部分
2. 这些服务设计为手动触发而非在启动时自动启用/运行
3. WantedBy 指令对于一次性服务来说是不必要的
4. 通过不加载不必要的服务来提高系统启动性能

## Summary by Sourcery

Remove installation sections from deepin-login-sound.service and deepin-shutdown-sound.service so they aren’t enabled at boot, reflecting their one-shot, manually triggered nature and improving system startup performance.

Bug Fixes:
- Remove [Install] sections and WantedBy directives from deepin-login-sound.service and deepin-shutdown-sound.service

Enhancements:
- Prevent unnecessary loading of these one-shot sound services to improve startup performance