### PR TITLE
fix(dde-open): Fix dde open crash issue

### DIFF
--- a/dde-open/main.go
+++ b/dde-open/main.go
@@ -54,16 +54,24 @@ func main() {
 	u, err := url.Parse(arg)
 	if err != nil {
 		gFile := gio.FileNewForCommandlineArg(arg)
-		scheme = gFile.GetUriScheme()
+		if gFile != nil {
+			scheme = gFile.GetUriScheme()
+		}
 		if scheme == "" {
 			logger.Warningf("failed to parse url %q: %v", arg, err)
 		}
 	} else {
 		scheme = u.Scheme
 	}
+	logger.Debugf("scheme: %q", scheme)
 	switch scheme {
 	case "file":
-		err = openFile(u.Path)
+		if u != nil {
+			err = openFile(u.Path)
+		} else {
+			// 如果u为nil，说明url.Parse失败了，应该作为普通文件路径处理
+			err = openFile(arg)
+		}
 
 	case "":
 		err = openFile(arg)


### PR DESCRIPTION
Fix the null pointer dereference crash caused by special character file names

Log: as title
pms: BUG-325569