### PR TITLE
chore: bump version to 6.0.22

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.22) unstable; urgency=medium
+
+  * fix(dde-open): Fix dde open crash issue
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 31 Jul 2025 19:43:39 +0800
+
 dde-api (6.0.21) unstable; urgency=medium
 
   * chore: remove huangli and lunar calendar components


### PR DESCRIPTION
update changelog to 6.0.22

## Summary by Sourcery

Chores:
- Update Debian changelog to version 6.0.22