### PR TITLE
chore: bump version to 6.0.23

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.23) unstable; urgency=medium
+
+  * chore: bump 1st-party dependencies revision in go.mod
+
+ -- fuleyi <fuleyi@uniontech.com>  Fri, 15 Aug 2025 09:02:57 +0800
+
 dde-api (6.0.22) unstable; urgency=medium
 
   * fix(dde-open): Fix dde open crash issue


### PR DESCRIPTION
update changelog to 6.0.23

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.0.23