### PR TITLE
fix: 解决没有关机音效的问题

### DIFF
--- a/misc/systemd/system/deepin-shutdown-sound.service
+++ b/misc/systemd/system/deepin-shutdown-sound.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Deepin shutdown sound
-Requisite=sound.target local-fs.target
+Requisite=
+Wants=sound.target local-fs.target
 After=sound.target local-fs.target
 Conflicts=shutdown.target
 Before=shutdown.target


### PR DESCRIPTION
因为用 Requisite= 是“硬依赖”。如果系统上没激活 sound.target（很多环境确实不会激活它），这个服务就不会在开机被拉起，结果就是 enabled 但一直 inactive (dead)

Log: 去掉Requisite，改成Wants
PMS: BUG-315787
Influence: 系统音效

## Summary by Sourcery

Bug Fixes:
- Replace Requisite=sound.target with Wants=sound.target in deepin-shutdown-sound.service to prevent the service from staying inactive in environments without sound.target