### PR TITLE
fix: add audio group permission to sound theme player service

### DIFF
--- a/misc/systemd/system/deepin-sound-theme-player.service
+++ b/misc/systemd/system/deepin-sound-theme-player.service
@@ -12,6 +12,7 @@ After=dbus.socket
 Type=dbus
 BusName=org.deepin.dde.SoundThemePlayer1
 User=deepin-daemon
+SupplementaryGroups=audio
 Environment=HOME=/var/lib/deepin-sound-player
 ExecStart=/usr/lib/deepin-api/sound-theme-player
 


### PR DESCRIPTION
- Added SupplementaryGroups=audio to ensure proper audio device access

Log: add audio group permission to sound theme player service
pms: BUG-333303