### PR TITLE
fix: add audio group permission to login and shutdown sound services

### DIFF
--- a/misc/systemd/system/deepin-login-sound.service
+++ b/misc/systemd/system/deepin-login-sound.service
@@ -6,6 +6,7 @@ After=dbus.service lightdm.service
 [Service]
 Type=oneshot
 User=deepin-daemon
+SupplementaryGroups=audio
 Environment=HOME=/var/lib/deepin-sound-player
 ExecStart=/usr/bin/dbus-send --system --print-reply --dest=org.deepin.dde.SoundThemePlayer1 /org/deepin/dde/SoundThemePlayer1 org.deepin.dde.SoundThemePlayer1.PlaySoundDesktopLogin
 RemainAfterExit=yes

--- a/misc/systemd/system/deepin-shutdown-sound.service
+++ b/misc/systemd/system/deepin-shutdown-sound.service
@@ -9,6 +9,7 @@ Before=shutdown.target
 [Service]
 Type=simple
 User=deepin-daemon
+SupplementaryGroups=audio
 Environment=HOME=/var/lib/deepin-sound-player
 ExecStart=/usr/bin/true
 ExecStop=/usr/lib/deepin-api/deepin-shutdown-sound


### PR DESCRIPTION
- Added SupplementaryGroups=audio to ensure proper audio device access for login and shutdown sounds

Log: add audio group permission to login and shutdown sound services
pms: BUG-333303