### PR TITLE
fix: copy background image to avoid re-encoding

### DIFF
--- a/adjust-grub-theme/main.go
+++ b/adjust-grub-theme/main.go
@@ -254,7 +254,15 @@ func setBackground(bgFile string) {
 	fallbackDir := getFallbackDir()
 	_, err = os.Stat(fallbackDir)
 	if err == nil {
-		err = saveJpeg(bgImg, filepath.Join(fallbackDir, "background.jpg"))
+		// 使用复制文件的方式避免重复编码
+		backgroundFile := filepath.Join(fallbackDir, "background.jpg")
+		err = saveJpeg(bgImg, backgroundFile)
+		if err != nil {
+			logger.Fatal(err)
+		}
+		// 复制文件到background_in_theme.jpg，确保desktop-image字段指向的文件也被更新
+		backgroundInThemeFile := filepath.Join(fallbackDir, "background_in_theme.jpg")
+		_, err = copyFile(backgroundFile, backgroundInThemeFile)
 		if err != nil {
 			logger.Fatal(err)
 		}


### PR DESCRIPTION
The original implementation was re-encoding the JPEG image when saving to both background.jpg and background_in_theme.jpg files, which could cause quality degradation and performance issues. This fix adds a copyFile function to duplicate the file without re-encoding, preserving image quality and improving efficiency.

Log: Fixed background image quality issue in GRUB theme

Influence:
1. Test that background images are properly displayed in GRUB menu
2. Verify both background.jpg and background_in_theme.jpg files are created
3. Check that image quality is maintained without artifacts
4. Test with different image formats and sizes
5. Verify the copy operation works correctly with file permissions

fix: 复制背景图片避免重复编码

原实现在保存到 background.jpg 和 background_in_theme.jpg 文件时都会重新 编码 JPEG 图像，这可能导致质量下降和性能问题。此修复添加了 copyFile 函数
来复制文件而不重新编码，保持图像质量并提高效率。

Log: 修复了 GRUB 主题中的背景图片质量问题

Influence:
1. 测试 GRUB 菜单中背景图片是否正确显示
2. 验证 background.jpg 和 background_in_theme.jpg 文件是否都创建成功
3. 检查图像质量是否保持，没有出现伪影
4. 使用不同格式和大小的图片进行测试
5. 验证复制操作是否正确处理文件权限

PMS: BUG-315809

## Summary by Sourcery

Use file copying instead of re-encoding for GRUB background images to preserve quality and improve efficiency.

Bug Fixes:
- Prevent JPEG quality degradation by avoiding redundant re-encoding of background images.

Enhancements:
- Introduce copyFile function to duplicate background.jpg as background_in_theme.jpg without re-encoding.