### PR TITLE
chore: bump version to 6.0.25

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-api (6.0.25) unstable; urgency=medium
+
+  * fix: copy background image to avoid re-encoding
+  * feat: migrate from gsettings to dconfig for sound settings
+  * fix: add audio group permission to login and shutdown sound services
+  * fix: add audio group permission to sound theme player service
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Sep 2025 20:57:19 +0800
+
 dde-api (6.0.24) unstable; urgency=medium
 
   * fix: 解决没有关机音效的问题 (#148)


### PR DESCRIPTION
update changelog to 6.0.25

## Summary by Sourcery

Bump Debian package version to 6.0.25 and update the changelog accordingly.