### PR TITLE
fix: 解决新装镜像创建用户后出现开机音效服务启动失败的问题

### DIFF
--- a/misc/scripts/deepin-boot-sound.sh
+++ b/misc/scripts/deepin-boot-sound.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/dbus-send --system --print-reply --dest=com.deepin.api.SoundThemePlayer /com/deepin/api/SoundThemePlayer com.deepin.api.SoundThemePlayer.PlaySoundDesktopLogin&
+/usr/bin/dbus-send --system --print-reply --dest=org.deepin.dde.SoundThemePlayer1 /org/deepin/dde/SoundThemePlayer1 org.deepin.dde.SoundThemePlayer1.PlaySoundDesktopLogin&

--- a/misc/systemd/system/deepin-login-sound.service
+++ b/misc/systemd/system/deepin-login-sound.service
@@ -8,7 +8,7 @@ Type=oneshot
 User=deepin-daemon
 SupplementaryGroups=audio
 Environment=HOME=/var/lib/deepin-sound-player
-ExecStart=/usr/bin/dbus-send --system --print-reply --dest=org.deepin.dde.SoundThemePlayer1 /org/deepin/dde/SoundThemePlayer1 org.deepin.dde.SoundThemePlayer1.PlaySoundDesktopLogin
+ExecStart=/usr/lib/deepin-api/deepin-boot-sound.sh
 RemainAfterExit=yes
 
 DevicePolicy=closed


### PR DESCRIPTION
创建用户时，lightdm已经启动了，这时候还没有用户，开机音效服务获取不到用户信息，导致运行报错。改成脚本执行，忽略报错。

Log: 开机音效服务中的二进制改成脚本执行，忽略运行报错
PMS: BUG-332437
Influence: login-sound.service