### PR TITLE
chore: bump version to 6.0.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.26) unstable; urgency=medium
+
+  * Release 6.0.26
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 18 Sep 2025 20:01:09 +0800
+
 dde-api (6.0.25) unstable; urgency=medium
 
   * fix: copy background image to avoid re-encoding


### PR DESCRIPTION
update changelog to 6.0.26