### PR TITLE
chore: bump version to 6.0.27

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.27) unstable; urgency=medium
+
+  * Release 6.0.27
+
+ -- fuleyi <fuleyi@uniontech.com>  Thu, 25 Sep 2025 20:51:52 +0800
+
 dde-api (6.0.26) unstable; urgency=medium
 
   * Release 6.0.26


### PR DESCRIPTION
update changelog to 6.0.27

## Summary by Sourcery

Build:
- Update debian/changelog to version 6.0.27