### PR TITLE
chore: bump version to 6.0.28

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.28) unstable; urgency=medium
+
+  * fix: 解决新装镜像创建用户后出现开机音效服务启动失败的问题 (#155)
+
+ -- fuleyi <fuleyi@uniontech.com>  Fri, 26 Sep 2025 09:20:31 +0800
+
 dde-api (6.0.27) unstable; urgency=medium
 
   * Release 6.0.27


### PR DESCRIPTION
update changelog to 6.0.28

## Summary by Sourcery

Documentation:
- Update Debian changelog to reflect version 6.0.28