### PR TITLE
feat: parallel build option for debian packaging

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 export GOCACHE = /tmp/gocache
 export GOPATH := /usr/share/gocode
+export DEB_BUILD_OPTIONS = parallel=16
 export GO111MODULE=off
 ifeq ($(DEB_BUILD_ARCH),sw_64)
 	export GOFLAGS = -vet=off


### PR DESCRIPTION
1. Update debian/rules to include export DEB_BUILD_OPTIONS = parallel=16
2. This allows the build process to utilize multiple cores during compilation

Log: Added parallel build option for faster Debian package generation

Influence:
1. Verify that the build completes successfully with the new parallel option
2. Test if the build produces the same output as with single-core compilation
3. Ensure compatibility with Debian build system requirements

改进Debian打包流程

1. 更新debian/rules文件添加环境变量设置 DEB_BUILD_OPTIONS = parallel=16
2. 此改动允许构建过程在编译期间利用多核心处理器资源

Log: 新增并行构建选项以加速Debian包生成

影响建议:
1. 验证带有新并行选项的构建过程是否能成功完成
2. 测试确保该选项生成的包与单核编译结果完全一致
3. 确保该配置符合Debian构建系统的技术规范