### PR TITLE
fix: Add golang-x-sys dependency for syscall operations

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,6 +25,7 @@ Build-Depends:
  golang-github-stretchr-testify-dev,
  golang-gopkg-alecthomas-kingpin.v2-dev,
  golang-gopkg-check.v1-dev,
+ golang-golang-x-sys-dev,
  libcairo2-dev,
  libcanberra-dev,
  libfreetype-dev | libfreetype6-dev,


### PR DESCRIPTION
This change adds the golang-golang-x-sys-dev package to the Build- Depends
list in debian/control file. The golang.org/x/sys package provides system
calls for Go programs, which are necessary for some platform-specific functionality in the project.

The addition was required to address specific syscalls needed during compilation or runtime, particularly for Debian packaging. Without this dependency, certain system-related operations would fail to build or run correctly on Debian systems.

Influence:
1. Test package build across Debian versions
2. Verify system calls work correctly after the change
3. Check if any other binary packages might be affected
4. Test Debian packaging process with CI automation

## Summary by Sourcery

Build:
- Added golang-golang-x-sys-dev to Build-Depends in debian/control for golang.org/x/sys support