### PR TITLE
chore: update changelog to 6.0.38

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.38) unstable; urgency=medium
+
+  * fix: Process for adapting v25 command line to set grub background
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 09 Apr 2026 20:29:00 +0800
+
 dde-api (6.0.37) unstable; urgency=medium
 
   * fix: 适配PS鼠标类型的触控板


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.38

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.38
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog metadata to reflect version 6.0.38.