### PR TITLE
chore: update changelog to 6.0.39

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.39) unstable; urgency=medium
+
+  * feat: add eventlogger.hpp header for DDE applications
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:42 +0800
+
 dde-api (6.0.38) unstable; urgency=medium
 
   * fix: Process for adapting v25 command line to set grub background


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.39

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.39
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog entries to document version 6.0.39.