### PR TITLE
fix: use QJsonObject for event logger messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,9 @@ install-misc:
 #Need to copy cpp-include/eventlogger.hpp to /usr/include
 	mkdir -pv ${DESTDIR}${CPP_INCLUDE_DIR}/dde-api
 	cp -R cpp-include/eventlogger.hpp ${DESTDIR}${CPP_INCLUDE_DIR}/dde-api
+#Install cmake config for find_package(DdeApi)
+	mkdir -pv ${DESTDIR}${PREFIX}/share/cmake/DDEAPI
+	cp -R cmake/DDEAPI/DDEAPIConfig.cmake ${DESTDIR}${PREFIX}/share/cmake/DDEAPI
 
 install-dev: ${addprefix install/lib/, ${ININSTALLS}}
 

--- a/cmake/DDEAPI/DDEAPIConfig.cmake
+++ b/cmake/DDEAPI/DDEAPIConfig.cmake
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# DdeApiConfig.cmake
+# Provides DdeApi::EventLogger imported target (header-only)
+#
+# Usage:
+#   find_package(DdeApi QUIET)
+#   if(DdeApi_FOUND)
+#     target_link_libraries(myapp PRIVATE DdeApi::EventLogger)
+#   endif()
+
+include_guard(GLOBAL)
+
+set(DDE_API_INCLUDE_DIRS "/usr/include")
+
+if(NOT TARGET DDEAPI::EventLogger)
+    add_library(DDEAPI::EventLogger INTERFACE IMPORTED)
+    set_target_properties(DDEAPI::EventLogger PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${DDE_API_INCLUDE_DIRS}"
+    )
+endif()
+
+set(DdeApi_FOUND TRUE)

--- a/cpp-include/eventlogger.hpp
+++ b/cpp-include/eventlogger.hpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLibrary>
+#include <DSGApplication>
 #include <DSysInfo>
 
 #include <mutex>
@@ -14,23 +15,15 @@
 #include <dlfcn.h>
 #include <unistd.h>
 
-// Enable logging for current system version (debug only, remove before release)
-// #define DDE_EVENTLOG_DEBUG_ENABLE_CURRENT_VERSION
-
 namespace DDE_EventLogger {
 
 // Check if event logging should be enabled based on system edition
 // Only UosProfessional is enabled by default
 inline bool shouldEnableEventLog()
 {
-#ifdef DDE_EVENTLOG_DEBUG_ENABLE_CURRENT_VERSION
-    // Debug mode: enable for current system version
-    return true;
-#else
     // Production mode: only enable for UosProfessional edition
     // Note: DSysInfo is in Dtk::Core namespace
     return Dtk::Core::DSysInfo::uosEditionType() == Dtk::Core::DSysInfo::UosProfessional;
-#endif
 }
 
 typedef bool (*Initialize)(const std::string &package_id, bool enable_sig);
@@ -40,16 +33,16 @@ typedef struct _EventLoggerData
 {
     qint64 tid;
     QString target;
-    QMap<QString, QString> message;
+    QJsonObject message;
 
     _EventLoggerData()
         : tid(0)
         , target(QString())
-        , message(QMap<QString, QString>())
+        , message(QJsonObject())
     {
     }
 
-    _EventLoggerData(qint64 tid, const QString &target, const QMap<QString, QString> &message)
+    _EventLoggerData(qint64 tid, const QString &target, const QJsonObject &message)
         : tid(tid)
         , target(target)
         , message(message)
@@ -82,40 +75,14 @@ public:
 
         std::lock_guard<std::mutex> lock(m_mutex);
         if (!m_initialized) {
+            doInit(QString::fromUtf8(Dtk::Core::DSGApplication::id()), false);
+        }
+        if (!m_initialized) {
             return;
         }
 
         QJsonDocument json = structToJson(data);
         m_writeEventLog(json.toJson(QJsonDocument::Compact).toStdString());
-    }
-
-    void writeEventLog(qint64 tid, const QString &target, const QString &key, const QString &value)
-    {
-        writeEventLog(EventLoggerData(tid, target, {{key, value}}));
-    }
-
-    bool init(QString package_id, bool enable_sig)
-    {
-        if (!shouldEnableEventLog()) {
-            return false;
-        }
-
-        std::lock_guard<std::mutex> lock(m_mutex);
-
-        if (nullptr == m_initialize || nullptr == m_writeEventLog) {
-            return false;
-        }
-
-        if (m_initialized) {
-            return true;
-        }
-
-        m_initialized = m_initialize(package_id.toStdString(), enable_sig);
-        if (!m_initialized) {
-            qDebug() << "Failed to initialize event logger";
-            return false;
-        }
-        return true;
     }
 
 private:
@@ -147,20 +114,30 @@ private:
     EventLogger(const EventLogger &) = delete;            // 禁止拷贝构造函数
     EventLogger &operator=(const EventLogger &) = delete; // 禁止赋值运算符
 
+    bool doInit(const QString &package_id, bool enable_sig)
+    {
+        if (nullptr == m_initialize || nullptr == m_writeEventLog) {
+            return false;
+        }
+
+        if (m_initialized) {
+            return true;
+        }
+
+        m_initialized = m_initialize(package_id.toStdString(), enable_sig);
+        if (!m_initialized) {
+            qDebug() << "Failed to initialize event logger";
+        }
+        return m_initialized;
+    }
+
     // 将结构体转换为 JSON 内容
     QJsonDocument structToJson(const EventLoggerData &data)
     {
         QJsonObject jsonObject;
         jsonObject["tid"] = data.tid;
         jsonObject["target"] = data.target;
-        QJsonObject msgJson;
-        QMapIterator<QString, QString> iterator(data.message);
-        while (iterator.hasNext()) {
-            iterator.next();
-            msgJson[iterator.key()] = iterator.value();
-        }
-
-        jsonObject["message"] = msgJson;
+        jsonObject["message"] = data.message;
         QJsonDocument jsonDocument(jsonObject);
         return jsonDocument;
     }

--- a/debian/dde-api-dev.install
+++ b/debian/dde-api-dev.install
@@ -1,2 +1,3 @@
 /usr/share/gocode/
 /usr/include/
+/usr/share/cmake/DDEAPI/


### PR DESCRIPTION
Use QJsonObject directly for EventLoggerData messages so JSON payloads are preserved when writing event logs. Remove the string key/value helper that no longer matches the object-based message payload.

使用 QJsonObject 直接承载 EventLoggerData 的 message 字段，确保写入事件日志时保留 JSON 载荷内容。移除不再匹配对象化 message 载荷的字符串键值辅助接口。

## Summary by Sourcery

Switch event logger message payloads to use QJsonObject instead of string maps to preserve structured JSON data.

Bug Fixes:
- Ensure event logger messages retain full JSON payloads by storing them as QJsonObject rather than flattening to string key/value pairs.

Enhancements:
- Remove the string-based writeEventLog helper and simplify JSON serialization by writing the QJsonObject message directly into the event log output.