### PR TITLE
chore: update changelog to 6.0.40

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-api (6.0.40) unstable; urgency=medium
+
+  * feat: add cmake find_package support and auto-init for EventLogger 为
+    EventLogger 添加 cmake find_package 支持和自动初始化
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 15:03:27 +0800
+
 dde-api (6.0.39) unstable; urgency=medium
 
   * feat: add eventlogger.hpp header for DDE applications


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.40

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.40
- 目标分支: master
