### PR TITLE
refactor(wacom): replace shell command with direct exec call

### DIFF
--- a/dxinput/wacom.go
+++ b/dxinput/wacom.go
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -88,14 +88,13 @@ func (w *Wacom) QueryType() int {
 // Set  the tablet input area in device coordinates in the form top
 // left x/y and bottom right x/y.
 func (w *Wacom) SetArea(x1, y1, x2, y2 int) error {
-	var cmd = fmt.Sprintf("%s set %v %s %v %v %v %v", cmdXSetWacom, w.Id,
-		cmdKeyArea, x1, y1, x2, y2)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyArea,
+		strconv.Itoa(x1), strconv.Itoa(y1),
+		strconv.Itoa(x2), strconv.Itoa(y2))
 }
 
 func (w *Wacom) ResetArea() error {
-	var cmd = fmt.Sprintf("%s set %v %s", cmdXSetWacom, w.Id, cmdKeyResetArea)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyResetArea)
 }
 
 func (w *Wacom) getIdAsStr() string {
@@ -130,9 +129,7 @@ func (w *Wacom) SetRotate(value string) error {
 		return fmt.Errorf("Invalid value: %s", value)
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %v", cmdXSetWacom, w.Id,
-		cmdKeyRotate, value)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyRotate, value)
 }
 
 // Button button-number [mapping]
@@ -148,9 +145,8 @@ func (w *Wacom) SetRotate(value string) error {
 // series  of  keystrokes,  in  this example "press a, press shift,
 // press and release b, release shift, release a".
 func (w *Wacom) SetButton(btn int, value string) error {
-	var cmd = fmt.Sprintf("%s set %v %s %v %s", cmdXSetWacom, w.Id,
-		cmdKeyButton, btn, value)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyButton,
+		strconv.Itoa(btn), value)
 }
 
 // Mode Absolute|Relative
@@ -166,9 +162,7 @@ func (w *Wacom) SetMode(mode string) error {
 	default:
 		return fmt.Errorf("Invalid value: %s", mode)
 	}
-	var cmd = fmt.Sprintf("%s set %v %s %s", cmdXSetWacom, w.Id,
-		cmdKeyMode, mode)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyMode, mode)
 }
 
 // PressureCurve  x1 y1 x2 y2
@@ -187,9 +181,9 @@ func (w *Wacom) SetPressureCurve(x1, y1, x2, y2 int) error {
 		return fmt.Errorf("Invalid value: %v %v %v %v", x1, y1, x2, y2)
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %v %v %v %v", cmdXSetWacom, w.Id,
-		cmdKeyPressureCurve, x1, y1, x2, y2)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyPressureCurve,
+		strconv.Itoa(x1), strconv.Itoa(y1),
+		strconv.Itoa(x2), strconv.Itoa(y2))
 }
 
 // Suppress level
@@ -202,9 +196,8 @@ func (w *Wacom) SetSuppress(value int) error {
 		return fmt.Errorf("Invalid value: %v", value)
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %v", cmdXSetWacom, w.Id,
-		cmdKeySuppress, value)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeySuppress,
+		strconv.Itoa(value))
 }
 
 // Threshold level
@@ -219,9 +212,8 @@ func (w *Wacom) SetThreshold(thres int) error {
 		return fmt.Errorf("Invalid value: %v", thres)
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %v", cmdXSetWacom, w.Id,
-		cmdKeyThreshold, thres)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyThreshold,
+		strconv.Itoa(thres))
 }
 
 // The the window size for incoming input tool raw data points
@@ -231,9 +223,8 @@ func (w *Wacom) SetRawSample(sample uint32) error {
 		return fmt.Errorf("Invalid raw sample: %v", sample)
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %v", cmdXSetWacom, w.Id,
-		cmdKeyRawSample, sample)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyRawSample,
+		strconv.FormatUint(uint64(sample), 10))
 }
 
 // Mapping PC screen to tablet, such as "VGA1"
@@ -242,14 +233,11 @@ func (w *Wacom) MapToOutput(output string) error {
 		return nil
 	}
 
-	var cmd = fmt.Sprintf("%s set %v %s %s", cmdXSetWacom, w.Id,
-		cmdKeyMapToOutput, output)
-	return doAction(cmd)
+	return doAction("set", w.getIdAsStr(), cmdKeyMapToOutput, output)
 }
 
-func doAction(cmd string) error {
-	// #nosec G204
-	out, err := exec.Command("/bin/sh", "-c", cmd).CombinedOutput()
+func doAction(args ...string) error {
+	out, err := exec.Command(cmdXSetWacom, args...).CombinedOutput()
 	if err != nil {
 		return errors.New(string(out))
 	}


### PR DESCRIPTION
1. Replace `doAction(string)` with `doAction(args ...string)` to avoid shell injection risk
2. Refactor all Wacom set methods to pass arguments individually instead of using fmt.Sprintf to build shell commands
3. Remove `exec.Command("/bin/sh", "-c", cmd)` in favor of `exec.Command(cmdXSetWacom, args...)` for safer command execution
4. Sort imports and add strconv/errors usage for integer/string conversions

Log: Replace unsafe shell command construction with direct exec.Command calls in wacom module

refactor(wacom): 用直接 exec 调用替换 shell 命令拼接

1. 将 `doAction(string)` 重构为 `doAction(args ...string)` 以消除 shell 注入风险
2. 重构所有 Wacom set 方法，改为逐个传参而非使用 fmt.Sprintf 拼接 shell 命令
3. 移除 `exec.Command("/bin/sh", "-c", cmd)` 改用 `exec.Command(cmdXSetWacom, args...)` 执行命令
4. 调整 import 排序，添加 strconv/errors 用于整数/字符串转换

Log: 将 wacom 模块中不安全的 shell 命令拼接替换为直接 exec.Command 调用
Change-Id: Ia4978b3f2920dd8f005dc6f1cff45470d956bb65