### PR TITLE
fix(grub-theme): 调整 1024x768 分辨率下启动菜单宽度，修复显示不完整问题

### DIFF
--- a/adjust-grub-theme/main.go
+++ b/adjust-grub-theme/main.go
@@ -1071,7 +1071,7 @@ func adjustBootMenuV25(comp *tt.Component, width, height int) {
 	if width == 1024 && height == 768 {
 		// halfWidthPercent represents half of the boot menu width percentage.
 		// The boot menu is centered, so width = halfWidthPercent * 2, left = 50% - halfWidthPercent,
-		halfWidthPercent := 22
+		halfWidthPercent := 27
 		comp.SetProp("width", tt.RelNum(halfWidthPercent*2))
 		comp.SetProp("left", tt.RelNum(50-halfWidthPercent))
 	}

--- a/adjust-grub-theme/version.go
+++ b/adjust-grub-theme/version.go
@@ -4,4 +4,4 @@
 
 package main
 
-const VERSION int = 19
+const VERSION int = 20

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-api (6.0.41) unstable; urgency=medium
+
+  * fix(grub-theme): 调整 1024x768 分辨率下启动菜单宽度，修复显示不完整问题
+
+ -- zengwei <zengwei@uniontech.com>  Fri, 09 May 2026 10:00:00 +0800
+
 dde-api (6.0.40) unstable; urgency=medium
 
   * feat: add cmake find_package support and auto-init for EventLogger 为


### PR DESCRIPTION
fix(grub-theme): 调整 1024x768 分辨率下启动菜单宽度，修复显示不完整问题

pms: 359281