### PR TITLE
chore: update changelog to 6.0.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-api (6.0.42) unstable; urgency=medium
+
+  * refactor(wacom): replace shell command with direct exec call
+  * fix: eliminate remaining memory leaks in application-tray
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 14 May 2026 20:03:21 +0800
+
 dde-api (6.0.41) unstable; urgency=medium
 
   * fix(grub-theme): 调整 1024x768 分辨率下启动菜单宽度，修复显示不完整问题


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.42

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.42
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog to reflect version 6.0.42 targeting master.