### PR TITLE
fix(eventlogger): change event log enable condition from professional-only to non-community

### DIFF
--- a/cpp-include/eventlogger.hpp
+++ b/cpp-include/eventlogger.hpp
@@ -18,12 +18,12 @@
 namespace DDE_EventLogger {
 
 // Check if event logging should be enabled based on system edition
-// Only UosProfessional is enabled by default
+// Enable for all editions except UosCommunity
 inline bool shouldEnableEventLog()
 {
-    // Production mode: only enable for UosProfessional edition
+    // Production mode: enable for all editions except UosCommunity
     // Note: DSysInfo is in Dtk::Core namespace
-    return Dtk::Core::DSysInfo::uosEditionType() == Dtk::Core::DSysInfo::UosProfessional;
+    return Dtk::Core::DSysInfo::uosEditionType() != Dtk::Core::DSysInfo::UosCommunity;
 }
 
 typedef bool (*Initialize)(const std::string &package_id, bool enable_sig);


### PR DESCRIPTION
为 EventLogger 事件日志启用条件由仅专业版改为非社区版

PMS: BUG-362029

## Summary by Sourcery

Bug Fixes:
- Correct event logger enablement condition so it is active on all non-community editions instead of only the professional edition.