### PR TITLE
fix(grub-theme): replace unsafe shell decode with Go string processing

### DIFF
--- a/adjust-grub-theme/util.go
+++ b/adjust-grub-theme/util.go
@@ -141,13 +141,16 @@ func eval(vars map[string]float64, expr string) (float64, error) {
 }
 
 func decodeShellValue(in string) string {
-	// #nosec G204
-	output, err := exec.Command("/bin/sh", "-c", "echo -n "+in).Output()
-	if err != nil {
-		// fallback
-		return strings.Trim(in, "\"")
+	in = strings.TrimSpace(in)
+	if len(in) >= 2 {
+		if in[0] == '"' && in[len(in)-1] == '"' {
+			return in[1 : len(in)-1]
+		}
+		if in[0] == '\'' && in[len(in)-1] == '\'' {
+			return in[1 : len(in)-1]
+		}
 	}
-	return string(output)
+	return in
 }
 
 const defaultGrubGfxMode = "auto"


### PR DESCRIPTION
## Summary

`decodeShellValue` used `exec.Command("/bin/sh", "-c", "echo -n "+in)` to strip shell quoting from grub config values (e.g. `GRUB_GFXMODE`), creating a command injection surface (CWE-78).

Replace with Go-native string processing that strips matching surrounding quotes (single or double) directly, eliminating the shell invocation entirely.

## Changes

`adjust-grub-theme/util.go` — `decodeShellValue` function:
- Remove `exec.Command("/bin/sh", "-c", "echo -n "+in)` and its `#nosec G204` override
- Use Go string processing: strip matching surrounding `"` or `'` quotes
- Return unquoted value as-is if no matching quotes found

## Verification

- [x] Build passes (`go build`)
- [x] Unit test (23 cases) passes on test machine
- [x] `uos-security-auditor shell-interpreter-security-check`: **Critical candidates: 0** (previously 1)
- [x] Deployed and verified on test machine (dde-api 6.0.43)
- [x] Manual validation: boot menu background setting works correctly

## Related

pms: BUG-364821