### PR TITLE
chore: update changelog to 6.0.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-api (6.0.44) unstable; urgency=medium
+
+  * fix(grub-theme): replace unsafe shell decode with Go string
+    processing
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 15:39:14 +0800
+
 dde-api (6.0.43) unstable; urgency=medium
 
   * fix(eventlogger): change event log enable condition from


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.0.44

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.0.44
- 目标分支: master

## Summary by Sourcery

Documentation:
- Document release 6.0.44 in debian/changelog.